### PR TITLE
feat(components): виджет Stats переведен на новое API

### DIFF
--- a/src/Stats/Stats.css
+++ b/src/Stats/Stats.css
@@ -1,26 +1,4 @@
 .cw--Stats {
-  display: grid;
-
-  grid-template-columns: min-content 1fr;
-  grid-column-gap: var(--column-gap);
-
-  align-items: baseline;
-  justify-items: start;
-
-  &_layout_default {
-    grid-template-areas:
-      'title title'
-      'number badge'
-      'unit unit';
-  }
-
-  &_layout_reversed {
-    grid-template-areas:
-      'title title'
-      'number unit'
-      'badge badge';
-  }
-
   &_size_2xs {
     --column-gap: var(--space-2xs);
 
@@ -30,7 +8,7 @@
   &_size_xs {
     --column-gap: var(--space-xs);
 
-    font-size: var(--size-text-2xl);
+    font-size: var(--size-text-3xl);
   }
 
   &_size_s {
@@ -51,22 +29,21 @@
     font-size: var(--size-text-6xl);
   }
 
-  &-Title {
-    grid-area: title;
+  &-Main {
+    display: flex;
+    align-items: baseline;
+
+    white-space: nowrap;
   }
 
   &-Value {
-    grid-area: number;
-
     font-size: inherit;
-  }
 
-  &-Badge {
-    font-size: 0.7em;
+    white-space: nowrap;
   }
 
   &-Value,
-  &-Badge {
+  &-Rate {
     &_status_success {
       color: var(--color-typo-success);
     }
@@ -82,9 +59,5 @@
     &_status_system {
       color: var(--color-typo-system);
     }
-  }
-
-  &-Unit {
-    grid-area: unit;
   }
 }

--- a/src/Stats/Stats.tsx
+++ b/src/Stats/Stats.tsx
@@ -1,107 +1,93 @@
-import React from 'react'
+import React, { forwardRef, HTMLAttributes } from 'react'
 
-import { Text, TextPropLineHeight, TextPropSize } from '@consta/uikit/Text'
-import { isDefined } from '@consta/widgets-utils/lib/type-guards'
+import { Text } from '@consta/uikit/Text'
+import { isNotNil } from '@consta/widgets-utils/lib/type-guards'
 
 import { FormatValue } from '@/__private__/types'
 import { cn } from '@/__private__/utils/bem'
 
-import { defaultValueFormatter } from './helpers'
+import {
+  defaultValueFormatter,
+  IconArrowRate,
+  IconTitle,
+  iconTitleSizes,
+  Layout,
+  Size,
+  Status,
+  titleSizes,
+} from './helpers'
 import './Stats.css'
+import { StatsRate } from './StatsRate/StatsRate'
+import { StatsTitle } from './StatsTitle/StatsTitle'
 
 const cnStats = cn('Stats')
 
-const sizes = ['2xs', 'xs', 's', 'm', 'l'] as const
-type Size = typeof sizes[number]
-
-const layouts = ['default', 'reversed'] as const
-type Layout = typeof layouts[number]
-
-const statuses = ['success', 'warning', 'error', 'system'] as const
-type Status = typeof statuses[number]
-
-type Props = {
-  value: number
-  size: Size
+type Props = HTMLAttributes<HTMLDivElement> & {
+  value: number | null
+  placeholder?: string
   title?: string
-  numberBadge?: number
+  iconTitle?: IconTitle
   unit?: string
-  layout?: Layout
+  rate?: string
+  iconArrowRate?: IconArrowRate
   status?: Status
-  withSign?: boolean
+  layout?: Layout
+  size?: Size
   formatValue?: FormatValue
   children?: never
 }
 
-const titleSizes: Record<Size, TextPropSize> = {
-  '2xs': 'xs',
-  xs: 'm',
-  s: 'l',
-  m: 'xl',
-  l: '2xl',
-}
-
-const numberBadgeLineHeight: Record<Size, TextPropLineHeight> = {
-  '2xs': 'xs',
-  xs: 'xs',
-  s: 'xs',
-  m: 's',
-  l: 's',
-}
-
-const getNumberSign = (value: number, isShow?: boolean) => {
-  return value > 0 && isShow ? '+' : ''
-}
-
-export const Stats: React.FC<Props> = ({
-  title,
-  value,
-  numberBadge,
-  unit,
-  size,
-  status,
-  layout = 'default',
-  withSign,
-  formatValue = defaultValueFormatter,
-}) => {
+export const Stats = forwardRef<HTMLDivElement, Props>((props, ref) => {
+  const {
+    value,
+    placeholder = '—',
+    title,
+    iconTitle,
+    rate,
+    iconArrowRate,
+    unit,
+    layout = 'default',
+    size = 'm',
+    status = 'system',
+    formatValue = defaultValueFormatter,
+    ...mainElementProps
+  } = props
+  const isDefaultLayout = layout === 'default'
   const valueModificators = {
-    status: isDefined(numberBadge) ? undefined : status,
+    status: !!rate ? undefined : status,
   }
 
+  const renderedIconTitle = iconTitle ? iconTitle({ size: iconTitleSizes[size] }) : null
+  const titleElement =
+    title || renderedIconTitle ? (
+      <StatsTitle size={size} icon={renderedIconTitle} title={title} />
+    ) : null
+
+  const rateElement = rate ? (
+    <StatsRate className={cnStats('Rate', { status })} rate={rate} icon={iconArrowRate} />
+  ) : null
+
+  const unitElement = unit ? (
+    <Text as="div" size={titleSizes[size]} lineHeight="s" view="secondary">
+      {unit}
+    </Text>
+  ) : null
+
   return (
-    <div className={cnStats({ layout, size })}>
-      <Text
-        className={cnStats('Title')}
-        as="div"
-        size={titleSizes[size]}
-        lineHeight="s"
-        view="primary"
-      >
-        {title}
-      </Text>
-
-      <Text className={cnStats('Value', valueModificators)} as="div" lineHeight="2xs" weight="bold">
-        {getNumberSign(value, withSign)}
-        {formatValue(value)}
-      </Text>
-
-      <Text
-        className={cnStats('Badge', { status })}
-        as="div"
-        lineHeight={numberBadgeLineHeight[size]}
-      >
-        {numberBadge}
-      </Text>
-
-      <Text
-        className={cnStats('Unit')}
-        as="div"
-        size={titleSizes[size]}
-        lineHeight="s"
-        view="secondary"
-      >
-        {unit}
-      </Text>
+    <div {...mainElementProps} ref={ref} className={cnStats({ layout, size })}>
+      {titleElement}
+      <div className={cnStats('Main')}>
+        <Text
+          className={cnStats('Value', valueModificators)}
+          as="div"
+          lineHeight="2xs"
+          weight="bold"
+        >
+          {isNotNil(value) ? formatValue(value) : placeholder}
+        </Text>
+        {isDefaultLayout ? rateElement : unitElement}
+      </div>
+      {isDefaultLayout ? unitElement : rateElement}
     </div>
   )
-}
+})

--- a/src/Stats/StatsRate/StatsRate.css
+++ b/src/Stats/StatsRate/StatsRate.css
@@ -1,0 +1,25 @@
+.cw--StatsRate {
+  font-size: 0.7em;
+
+  white-space: nowrap;
+
+  &-Icon {
+    font-size: 0.75em;
+
+    display: inline-block;
+
+    width: 0;
+    height: 0;
+    margin-right: var(--space-3xs);
+
+    border-top: 0;
+    border-right: 0.4em solid transparent;
+    border-bottom: 0.6em solid currentColor;
+    border-left: 0.4em solid transparent;
+
+    &_isNegative {
+      border-top: 0.6em solid currentColor;
+      border-bottom: 0;
+    }
+  }
+}

--- a/src/Stats/StatsRate/StatsRate.tsx
+++ b/src/Stats/StatsRate/StatsRate.tsx
@@ -1,0 +1,30 @@
+import React, { FC } from 'react'
+
+import { Text } from '@consta/uikit/Text'
+
+import { cn } from '@/__private__/utils/bem'
+
+import { IconArrowRate, isNegativeRate, replaceRateSign } from '../helpers'
+
+import './StatsRate.css'
+
+const cnStatsRate = cn('StatsRate')
+
+type Props = {
+  rate: string
+  icon?: IconArrowRate
+  className?: string
+  children?: never
+}
+
+export const StatsRate: FC<Props> = ({ rate, icon, className }) => {
+  const computedRate = icon ? replaceRateSign(rate) : rate
+  const isNegative = icon === 'down' || (icon === 'auto' && isNegativeRate(rate))
+
+  return (
+    <Text className={cnStatsRate(null, [className])} as="div" lineHeight="2xs">
+      {icon && <div className={cnStatsRate('Icon', { isNegative })} />}
+      {computedRate}
+    </Text>
+  )
+}

--- a/src/Stats/StatsTitle/StatsTitle.css
+++ b/src/Stats/StatsTitle/StatsTitle.css
@@ -1,0 +1,32 @@
+.cw--StatsTitle {
+  display: table;
+
+  &-Cell {
+    display: table-cell;
+  }
+
+  &-Icon {
+    line-height: 1em;
+
+    display: inline-block;
+
+    vertical-align: middle;
+
+    &_size_2xs {
+      width: var(--graphics-size-xs);
+      height: var(--graphics-size-xs);
+    }
+
+    &_size_xs,
+    &_size_s {
+      width: var(--graphics-size-s);
+      height: var(--graphics-size-s);
+    }
+
+    &_size_m,
+    &_size_l {
+      width: var(--graphics-size-m);
+      height: var(--graphics-size-m);
+    }
+  }
+}

--- a/src/Stats/StatsTitle/StatsTitle.tsx
+++ b/src/Stats/StatsTitle/StatsTitle.tsx
@@ -1,0 +1,37 @@
+import React, { FC, ReactNode } from 'react'
+
+import { Text } from '@consta/uikit/Text'
+
+import { cn } from '@/__private__/utils/bem'
+
+import { Size, titleSizes } from '../helpers'
+
+import './StatsTitle.css'
+
+const cnStatsTitle = cn('StatsTitle')
+
+type Props = {
+  size: Size
+  icon?: ReactNode
+  title?: string
+  className?: string
+  children?: never
+}
+
+export const StatsTitle: FC<Props> = ({ size, icon, title, className }) => {
+  return (
+    <Text
+      className={cnStatsTitle(null, [className])}
+      as="div"
+      size={titleSizes[size]}
+      view="primary"
+    >
+      {icon && (
+        <div className={cnStatsTitle('Cell')}>
+          <div className={cnStatsTitle('Icon', { size })}>{icon}</div>
+        </div>
+      )}
+      <div className={cnStatsTitle('Cell')}>{title}</div>
+    </Text>
+  )
+}

--- a/src/Stats/__mocks__/examples.mock.ts
+++ b/src/Stats/__mocks__/examples.mock.ts
@@ -5,10 +5,11 @@ import { Stats } from '../Stats'
 type Props = ComponentProps<typeof Stats>
 
 export const exampleData: Props = {
-  title: '',
-  value: 146,
-  numberBadge: 20,
-  unit: 'единицы',
+  value: 2170,
+  title: 'Молний за год',
+  unit: 'разрядов',
+  rate: '20%',
+  status: 'success',
   layout: 'default',
   size: 'xs',
 }

--- a/src/Stats/__stories__/Stats.mdx
+++ b/src/Stats/__stories__/Stats.mdx
@@ -1,7 +1,6 @@
 import {
   StatsExampleContent,
   StatsExampleContentOther,
-  StatsExampleContentWithSign,
   StatsExampleContentLong,
 } from './examples/StatsExampleContent'
 import {
@@ -15,6 +14,18 @@ import {
   StatsExampleLayoutDefault,
   StatsExampleLayoutReversed,
 } from './examples/StatsExampleLayout'
+import {
+  StatsExampleRateUp,
+  StatsExampleRateDown,
+  StatsExampleRateAutoPositive,
+  StatsExampleRateAutoNegative,
+} from './examples/StatsExampleRate'
+import {
+  StatsExampleSuccess,
+  StatsExampleWarning,
+  StatsExampleError,
+  StatsExampleSystem,
+} from './examples/StatsExampleStatus'
 
 # Stats
 
@@ -27,6 +38,9 @@ import {
   - [Плюс в начале](#плюс-в-начале)
   - [Длинные строчки](#длинные-строчки)
 - [Варианты отображения](#варианты-отображения)
+  - [layout](#layout)
+  - [status](#status)
+  - [size](#size)
 - [Размер](#размер)
 - [Список свойств](#свойства)
 - [Пример использования](#пример)
@@ -40,29 +54,21 @@ import {
 **Единицы** — подпись под числом, обычно тут указывают единицы измерения — км/ч, сутки, баррели или ведерки.
 Задается в свойстве `units`.
 
-**Показатель изменений** появляется справа или снизу, задается через `numberBadge`.
+**Показатель изменений** — появляется справа или снизу, задается через `rate`, отображает как изменился показатель в течении определенного времени.
 
 <StatsExampleContent />
 
 ```tsx
-<Stats title="Заголовок" value={146} numberBadge={100} unit="единиц" layout="full" size="s" />
-```
-
-### Плюс в начале
-
-Можно поставить перед числом плюс — чтобы показать, что что-то увеличилось. Для этого добавьте свойство `withSign`.
-
-<StatsExampleContentWithSign />
-
-```tsx
 <Stats
-  title="Выработка"
-  value={250}
-  numberBadge={20}
-  unit="тысяч тонн в час"
-  layout="full"
+  value={2170}
+  title="Молний за год"
+  iconTitle={<svg />}
+  unit="разрядов"
+  rate="20%"
+  iconArrowRate
+  status="success"
+  layout="default"
   size="s"
-  withSign
 />
 ```
 
@@ -72,47 +78,94 @@ import {
 
 <StatsExampleContentLong />
 
+### Парсинг показателя изменений
+
 ## Варианты отображения
 
-Вы можете выбрать, как показывать компонент: полностью, только с заголовком, только с единицами или как-то еще.
-Варианты: `'default'`, `'reversed'`.
+### iconArrowRate
+
+Если указать любое значение для иконки, то у самого первого числа в строке `rate` будет удален знак (`+` или `-`), если он был.
+
+**up**
+
+<StatsExampleRateUp />
+
+**down**
+
+<StatsExampleRateDown />
+
+**auto**
+
+При автоматическом определении варианта иконки парсится только самое первое число в строке `rate`, и на основе его знака определяется положительная или отрицательная иконка.
+
+| с позитивным числом              | с негативным числом              |
+| -------------------------------- | -------------------------------- |
+| <StatsExampleRateAutoPositive /> | <StatsExampleRateAutoNegative /> |
+
+### status
+
+| success                 | warning                 | error                 | system                 |
+| ----------------------- | ----------------------- | --------------------- | ---------------------- |
+| <StatsExampleSuccess /> | <StatsExampleWarning /> | <StatsExampleError /> | <StatsExampleSystem /> |
+
+### layout
 
 | default                       | reversed                       |
 | ----------------------------- | ------------------------------ |
 | <StatsExampleLayoutDefault /> | <StatsExampleLayoutReversed /> |
 
-## Размер
+### size
 
-За размер отвечает свойство `size`. Варианты: `'2xs'`, `'xs'`, `'s'`, `'m'`, `'l'`.
+**2xs**
 
-| 2xs                     | xs                     | s                     | m                     | l                     |
-| ----------------------- | ---------------------- | --------------------- | --------------------- | --------------------- |
-| <StatsExampleSize2XS /> | <StatsExampleSizeXS /> | <StatsExampleSizeS /> | <StatsExampleSizeM /> | <StatsExampleSizeL /> |
+<StatsExampleSize2XS />
+
+**xs**
+
+<StatsExampleSizeXS />
+
+**s**
+
+<StatsExampleSizeS />
+
+**m**
+
+<StatsExampleSizeM />
+
+**l**
+
+<StatsExampleSizeL />
 
 ## Свойства
 
-<!-- props:start -->
-
-| Свойство                            | Тип                                       | По умолчанию                | Описание                                                                                             |
-| ----------------------------------- | ----------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------- |
-| [`value`](#как-использовать)        | `number`                                  | -                           | Число, которое нужно показать                                                                        |
-| [`withSign?`](#плюс-в-начале)       | `boolean`                                 | -                           | Добавляет плюс перед числом                                                                          |
-| [`title?`](#как-использовать)       | `string`                                  | -                           | Надпись над числом, заголовок — поясняет, что это                                                    |
-| [`numberBadge?`](#как-использовать) | `number`                                  | -                           | Число для отображения показателя изменений                                                           |
-| [`unit?`](#как-использовать)        | `string`                                  | -                           | Надпись под числом, единицы — поясняет, в каких единицах измеряется число                            |
-| [`layout?`](#варианты-отображения)  | `'default', 'reversed'`                   | `'default'`                 | Вариант отображения                                                                                  |
-| `status?`                           | `'success', 'warning', 'errro', 'system'` | -                           | Статус влияет на цвет показателя изменений или на основное число если показатель изменений не указан |
-| `formatValue?`                      | `(value: number) => string`               | `(value: number) => string` | Метод форматирования value, по умолчанию добавляет отбивки в число                                   |
-| [`size?`](#размер)                  | `'2xs', 'xs', 's', 'm', 'l'`              | `'xs'`                      | Размер компонента                                                                                    |
+| Свойство                           | Тип                                       | По умолчанию                | Описание                                                                                             |
+| ---------------------------------- | ----------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [`value`](#как-использовать)       | `number | null`                           | -                           | Число, которое нужно показать                                                                        |
+| `placeholder`                      | `string`                                  | `'—'`                       | Значение которое отображается если в `value` был передан `null`                                      |
+| [`title?`](#как-использовать)      | `string`                                  | -                           | Надпись над числом, заголовок — поясняет, что это                                                    |
+| `iconTitle?`                       | `ReactNode`                               | -                           | Иконка рядом с заголовком, отображается всегда у первой строки                                       |
+| [`unit?`](#как-использовать)       | `string`                                  | -                           | Поясняет, в каких единицах измеряется число, меняет положение в зависимости от `layout`              |
+| [`rate?`](#как-использовать)       | `string`                                  | -                           | Строка содержащая показатель изменений, меняет положение в зависимости от `layout`                   |
+| [`iconArrowRate?`](#iconArrowRate) | `'up', 'down', 'auto'`                    | -                           | Иконка которая будет отображаться рядом с показателем изменений                                      |
+| [`status?`](#status)               | `'success', 'warning', 'error', 'system'` | `'system'`                  | Статус влияет на цвет показателя изменений или на основное число если показатель изменений не указан |
+| [`layout?`](#layout)               | `'default', 'reversed'`                   | `'default'`                 | Вариант отображения                                                                                  |
+| [`size?`](#size)                   | `'2xs', 'xs', 's', 'm', 'l'`              | `'m'`                       | Размер компонента                                                                                    |
+| `formatValue?`                     | `(value: number) => string`               | `(value: number) => string` | Метод форматирования основного числа, по умолчанию добавляет отбивки в число                         |
 
 ## Пример
 
 ```tsx
-// src/App.ts
 import React from 'react'
 import { Stats } from '@consta/widgets/Stats'
 
-const App = () => (
-  <Stats title="Заголовок" value={146} numberBadge={20} unit="единицы" layout="full" size="s" />
+const SomeComponent = () => (
+  <Stats
+    value={2170}
+    title="Молний за год"
+    unit="разрядов"
+    rate="20%"
+    iconArrowRate
+    status="success"
+  />
 )
 ```

--- a/src/Stats/__stories__/Stats.stories.tsx
+++ b/src/Stats/__stories__/Stats.stories.tsx
@@ -1,32 +1,56 @@
 import React from 'react'
 
-import { withSmartKnobs } from 'storybook-addon-smart-knobs'
+import { IconLightningBolt } from '@consta/uikit/IconLightningBolt'
+import { number, select, text } from '@storybook/addon-knobs'
 
-import { createMetadata, createStory } from '@/__private__/storybook'
+import { createMetadata, createStory, optionalSelect } from '@/__private__/storybook'
+import { FormatValue } from '@/__private__/types'
 
 import { Stats } from '..'
+import {
+  defaultValueFormatter,
+  iconsArrowRate,
+  IconTitle,
+  layouts,
+  sizes,
+  statuses,
+} from '../helpers'
 
 import mdx from './Stats.mdx'
 
-export const Interactive = createStory(() => (
-  <Stats title="Сроки" value={217} numberBadge={20} unit="суток" size="xs" layout="default" />
-))
+const iconsKeysTitle = ['Без иконки', 'IconLightningBolt'] as const
+const iconsTitle: Record<typeof iconsKeysTitle[number], IconTitle | undefined> = {
+  'Без иконки': undefined,
+  IconLightningBolt,
+}
 
-export const WithLineBreak = createStory(() => (
-  <Stats
-    title="Сроки срочные сроки срочные сроки срочные"
-    value={217000}
-    numberBadge={20}
-    unit="суток / час / суток / час / суток / час"
-    size="xs"
-    layout="default"
-  />
-))
+const formatsValueKeys = ['По умолчанию', 'Без форматирования'] as const
+const formatsValue: Record<typeof formatsValueKeys[number], FormatValue> = {
+  'По умолчанию': defaultValueFormatter,
+  'Без форматирования': String,
+}
+
+const getKnobs = () => {
+  return {
+    value: number('value', 2170),
+    placeholder: text('placeholder', '—'),
+    title: text('title', 'Молний за год'),
+    iconTitle: iconsTitle[select('iconTitle', iconsKeysTitle, iconsKeysTitle[0])],
+    unit: text('unit', 'разрядов'),
+    rate: text('rate', '20%'),
+    iconArrowRate: optionalSelect('iconArrowRate', iconsArrowRate),
+    status: select('status', statuses, statuses[0]),
+    layout: select('layout', layouts, layouts[0]),
+    size: select('size', sizes, sizes[3]),
+    formatValue: formatsValue[select('formatValue', formatsValueKeys, formatsValueKeys[0])],
+  }
+}
+
+export const Interactive = createStory(() => <Stats {...getKnobs()} />)
 
 export default createMetadata({
   title: 'Компоненты|/Stats',
   id: 'components/Stats',
-  decorators: [withSmartKnobs()],
   parameters: {
     docs: {
       page: mdx,

--- a/src/Stats/__stories__/examples/StatsExampleContent.tsx
+++ b/src/Stats/__stories__/examples/StatsExampleContent.tsx
@@ -1,39 +1,25 @@
 import React from 'react'
 
+import { IconLightningBolt } from '@consta/uikit/IconLightningBolt'
+
 import { Example } from '@/__private__/storybook'
 
 import { Stats } from '../..'
+import { exampleData } from '../../__mocks__/examples.mock'
 
 export const StatsExampleContent = () => (
   <Example width="200px">
-    <Stats title="Заголовок" value={146} numberBadge={20} unit="единиц" layout="default" size="s" />
-  </Example>
-)
-
-export const StatsExampleContentWithSign = () => (
-  <Example width="200px">
-    <Stats
-      title="Выработка"
-      value={250}
-      numberBadge={20}
-      unit="тысяч тонн в час"
-      layout="default"
-      size="s"
-      withSign
-    />
+    <Stats {...exampleData} />
   </Example>
 )
 
 export const StatsExampleContentLong = () => (
-  <Example width="200px">
+  <Example width="180px">
     <Stats
-      title="В этом году весна особенно прекрасна"
-      value={17}
-      numberBadge={20}
-      unit="счастливых мгновений для каждого"
-      layout="default"
-      size="s"
-      withSign
+      {...exampleData}
+      title="Молний за год произошло в Роcсии"
+      iconTitle={IconLightningBolt}
+      unit="дополнительный комментарий"
     />
   </Example>
 )

--- a/src/Stats/__stories__/examples/StatsExampleRate.tsx
+++ b/src/Stats/__stories__/examples/StatsExampleRate.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+import { Example } from '@/__private__/storybook'
+
+import { Stats } from '../..'
+import { exampleData } from '../../__mocks__/examples.mock'
+
+export const StatsExampleRateUp = () => (
+  <Example>
+    <Stats {...exampleData} size="2xs" rate="20%" iconArrowRate="up" />
+  </Example>
+)
+
+export const StatsExampleRateDown = () => (
+  <Example>
+    <Stats {...exampleData} size="2xs" rate="20%" iconArrowRate="down" status="error" />
+  </Example>
+)
+
+export const StatsExampleRateAutoPositive = () => (
+  <Example>
+    <Stats {...exampleData} size="2xs" rate="+20%" iconArrowRate="auto" />
+  </Example>
+)
+
+export const StatsExampleRateAutoNegative = () => (
+  <Example>
+    <Stats {...exampleData} size="2xs" rate="-20%" status="error" iconArrowRate="auto" />
+  </Example>
+)

--- a/src/Stats/__stories__/examples/StatsExampleSize.tsx
+++ b/src/Stats/__stories__/examples/StatsExampleSize.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { IconLightningBolt } from '@consta/uikit/IconLightningBolt'
+
 import { Example } from '@/__private__/storybook'
 
 import { Stats } from '../..'
@@ -7,30 +9,30 @@ import { exampleData } from '../../__mocks__/examples.mock'
 
 export const StatsExampleSize2XS = () => (
   <Example>
-    <Stats {...exampleData} size="2xs" />
+    <Stats {...exampleData} iconTitle={IconLightningBolt} size="2xs" />
   </Example>
 )
 
 export const StatsExampleSizeXS = () => (
   <Example>
-    <Stats {...exampleData} size="xs" />
+    <Stats {...exampleData} iconTitle={IconLightningBolt} size="xs" />
   </Example>
 )
 
 export const StatsExampleSizeS = () => (
   <Example>
-    <Stats {...exampleData} size="s" />
+    <Stats {...exampleData} iconTitle={IconLightningBolt} size="s" />
   </Example>
 )
 
 export const StatsExampleSizeM = () => (
   <Example>
-    <Stats {...exampleData} size="m" />
+    <Stats {...exampleData} iconTitle={IconLightningBolt} size="m" />
   </Example>
 )
 
 export const StatsExampleSizeL = () => (
   <Example>
-    <Stats {...exampleData} size="l" />
+    <Stats {...exampleData} iconTitle={IconLightningBolt} size="l" />
   </Example>
 )

--- a/src/Stats/__stories__/examples/StatsExampleStatus.tsx
+++ b/src/Stats/__stories__/examples/StatsExampleStatus.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+import { Example } from '@/__private__/storybook'
+
+import { Stats } from '../..'
+import { exampleData } from '../../__mocks__/examples.mock'
+
+export const StatsExampleSuccess = () => (
+  <Example>
+    <Stats {...exampleData} size="2xs" />
+  </Example>
+)
+
+export const StatsExampleWarning = () => (
+  <Example>
+    <Stats {...exampleData} size="2xs" status="warning" />
+  </Example>
+)
+
+export const StatsExampleError = () => (
+  <Example>
+    <Stats {...exampleData} size="2xs" status="error" />
+  </Example>
+)
+
+export const StatsExampleSystem = () => (
+  <Example>
+    <Stats {...exampleData} size="2xs" status="system" />
+  </Example>
+)

--- a/src/Stats/__tests__/Stats.test.tsx
+++ b/src/Stats/__tests__/Stats.test.tsx
@@ -12,6 +12,6 @@ const renderComponent = (props: Props) => {
 
 describe('Компонент Stats', () => {
   it('render без ошибок', () => {
-    expect(() => renderComponent({ size: '2xs', value: 100 })).not.toThrow()
+    expect(() => renderComponent({ value: 100 })).not.toThrow()
   })
 })

--- a/src/Stats/__tests__/helpers.test.ts
+++ b/src/Stats/__tests__/helpers.test.ts
@@ -1,6 +1,6 @@
 import { NARROW_NO_BREAK_SPACE } from '@/__private__/utils/symbols'
 
-import { defaultValueFormatter } from '../helpers'
+import { defaultValueFormatter, isNegativeRate } from '../helpers'
 
 describe('defaultValueFormatter', () => {
   it('добавляет отбивку в числа', () => {
@@ -15,5 +15,43 @@ describe('defaultValueFormatter', () => {
     const expected = '100,99'
 
     expect(received).toBe(expected)
+  })
+})
+
+describe('isNegativeNumber', () => {
+  it('проверяет что число из строки положительное игнорируя все остальные символы', () => {
+    const received = isNegativeRate(' +20% ')
+
+    expect(received).toBeFalse()
+  })
+
+  it('проверяет что число из строки положительное', () => {
+    const received = isNegativeRate('20')
+
+    expect(received).toBeFalse()
+  })
+
+  it('проверяет что число из строки отрицательное игнорируя все остальные символы', () => {
+    const received = isNegativeRate(' -20% ')
+
+    expect(received).toBeTrue()
+  })
+
+  it('проверяет что число из строки отрицательное', () => {
+    const received = isNegativeRate('-20')
+
+    expect(received).toBeTrue()
+  })
+
+  it('игнорирует знак если он указан не перед числом', () => {
+    const received = isNegativeRate('- 20')
+
+    expect(received).toBeFalse()
+  })
+
+  it('выбирает первое число из строки', () => {
+    const received = isNegativeRate('10 -20')
+
+    expect(received).toBeFalse()
   })
 })

--- a/src/Stats/helpers.ts
+++ b/src/Stats/helpers.ts
@@ -1,8 +1,53 @@
+import { ReactNode } from 'react'
+
+import { TextPropSize } from '@consta/uikit/Text'
+
 import { FormatValue } from '@/__private__/types'
+import { IconSize } from '@/__private__/utils/consta'
 import { NARROW_NO_BREAK_SPACE } from '@/__private__/utils/symbols'
+
+export const sizes = ['2xs', 'xs', 's', 'm', 'l'] as const
+export type Size = typeof sizes[number]
+
+export const layouts = ['default', 'reversed'] as const
+export type Layout = typeof layouts[number]
+
+export const statuses = ['success', 'warning', 'error', 'system'] as const
+export type Status = typeof statuses[number]
+
+export const iconsArrowRate = ['up', 'down', 'auto'] as const
+export type IconArrowRate = typeof iconsArrowRate[number]
+
+export type IconTitle = (props: { size: IconSize }) => ReactNode
+
+export const titleSizes: Record<Size, TextPropSize> = {
+  '2xs': 'xs',
+  xs: 'm',
+  s: 'l',
+  m: 'xl',
+  l: '2xl',
+}
+
+export const iconTitleSizes: Record<Size, IconSize> = {
+  '2xs': 'xs',
+  xs: 's',
+  s: 's',
+  m: 'm',
+  l: 'm',
+}
 
 export const defaultValueFormatter: FormatValue = value => {
   return String(value)
     .replace(/(\d)(?=(\d{3})+(?!\d))/g, `$1${NARROW_NO_BREAK_SPACE}`)
     .replace('.', ',')
+}
+
+export const isNegativeRate = (rate: string) => {
+  const [match] = /-?[0-9]+/.exec(rate) || []
+
+  return Number(match) < 0
+}
+
+export const replaceRateSign = (rate: string) => {
+  return rate.replace(/[-+](?=[0-9]+)/, '')
 }

--- a/src/__private__/utils/consta.ts
+++ b/src/__private__/utils/consta.ts
@@ -1,0 +1,2 @@
+export const iconSizes = ['xs', 's', 'm'] as const
+export type IconSize = typeof iconSizes[number]


### PR DESCRIPTION
BREAKING CHANGE:
В виджете больше не используются настройки `badge` и `numberBadge` для настройки отображения показателя
изменений.

## Описание задачи

Удалить старый API виджета и привести его в соответствии с требованиями заказчика из макета. Внешний вид включая отступы в этом PR не правились, в основном только API и добавление возможности вывода иконок.

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [x] Тесты: новый функционал и исправленные баги покрыты тестами
- [x] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [x] Сторибук: для компонентов написаны или обновлены stories
- [x] Верстка: используются переменные из UI-kit
- [x] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-widgets.consta.vercel.app/?path=/docs/common-develop-commits-style--page)
