### PR TITLE
fix(components): виджет Stats текст в unit при расположении reversed переносится на новые строки

### DIFF
--- a/src/Stats/Stats.css
+++ b/src/Stats/Stats.css
@@ -39,8 +39,6 @@
     align-items: baseline;
 
     margin: var(--gap) 0;
-
-    white-space: nowrap;
   }
 
   &-Value {


### PR DESCRIPTION
## Описание изменений

В режиме reversed виджета Stats пропс unit должен переноситься на новые строки.

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются переменные из UI-kit
- [x] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-widgets.consta.vercel.app/?path=/docs/common-develop-commits-style--page)
