### PR TITLE
feat(components): расчет ширины линии в виджете DonutChart учитывает размеры виджета

### DIFF
--- a/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
@@ -97,12 +97,12 @@ export const CoreDonutChart: React.FC<Props> = ({
   const svgHeight = isHalfDonutHorizontal ? mainRadius : size
   const viewBox = `${svgOffsetX}, ${svgOffsetY}, ${svgWidth}, ${svgHeight}`
   const circlesCount = getCirclesCount(data)
-  const sizeDonut = getSizeDonut(circlesCount, isDefined(textData), halfDonut)
+  const sizeDonut = getSizeDonut(circlesCount, size)
   const minChartSize = getMinChartSize(circlesCount, isDefined(textData), halfDonut)
   const isTooltipVisible = Boolean(tooltipData.length)
 
   const lineRadiuses: readonly LineRadius[] = createArrayOfIndexes(circlesCount).map(index => {
-    const outerRadius = getDonutRadius(mainRadius, index, circlesCount)
+    const outerRadius = getDonutRadius({ mainRadius, index, circlesCount, chartSize: size })
     const innerRadius = outerRadius - sizeDonut
 
     return {

--- a/src/__private__/components/CoreDonutChart/__tests__/helpers.test.ts
+++ b/src/__private__/components/CoreDonutChart/__tests__/helpers.test.ts
@@ -3,14 +3,12 @@ import { times } from 'lodash'
 import {
   defaultGetCirclesCount,
   defaultGetMinChartSize,
-  donutSize,
   getChartSize,
   getDonutRadius,
   getPadding,
   getSizeDonut,
   MAX_CIRCLES_TO_RENDER,
   minChartSize,
-  paddingBetweenDonuts,
 } from '../helpers'
 
 const LINES = [1, 2, 3] as const
@@ -33,56 +31,56 @@ describe('getChartSize', () => {
 
 describe('getPadding', () => {
   it('получение размера отступа между линиями графика', () => {
-    LINES.map(l => {
-      expect(getPadding(l)).toEqual(paddingBetweenDonuts[l])
-    })
+    expect(getPadding(1, 100)).toEqual(0)
+    expect(getPadding(2, 100)).toEqual(8)
+    expect(getPadding(3, 100)).toEqual(6)
   })
 })
 
 describe('getSizeDonut', () => {
   it('получение размера толщины линии графика', () => {
-    LINES.map(l => {
-      expect(getSizeDonut(l)).toEqual(donutSize[l])
-    })
-  })
-
-  it('получение размера толщины линии графика с текстом', () => {
-    expect(getSizeDonut(1, true)).toEqual(16)
-  })
-
-  it('получение размера толщины линии обрезанного графика без текста', () => {
-    LINES.map(l => {
-      expect(getSizeDonut(l, false, 'top')).toEqual(16)
-      expect(getSizeDonut(l, false, 'right')).toEqual(16)
-      expect(getSizeDonut(l, false, 'bottom')).toEqual(16)
-      expect(getSizeDonut(l, false, 'left')).toEqual(16)
-    })
-  })
-
-  it('получение размера толщины линии обрезанного графика с текстом', () => {
-    LINES.map(l => {
-      expect(getSizeDonut(l, true, 'top')).toEqual(16)
-      expect(getSizeDonut(l, true, 'right')).toEqual(16)
-      expect(getSizeDonut(l, true, 'bottom')).toEqual(16)
-      expect(getSizeDonut(l, true, 'left')).toEqual(16)
-    })
+    expect(getSizeDonut(1, 100)).toEqual(12)
+    expect(getSizeDonut(2, 100)).toEqual(10)
+    expect(getSizeDonut(3, 100)).toEqual(8)
   })
 })
 
 describe('getDonutRadius', () => {
-  const MAIN_RADIUS = 500
+  const MAIN_RADIUS = 50
   const COUNT_LINES = LINES.length
+  const SIZE = 100
 
   it('получение размера радиуса первой линии', () => {
-    expect(getDonutRadius(MAIN_RADIUS, 0, COUNT_LINES)).toEqual(500)
+    const received = getDonutRadius({
+      mainRadius: MAIN_RADIUS,
+      index: 0,
+      circlesCount: COUNT_LINES,
+      chartSize: SIZE,
+    })
+
+    expect(received).toEqual(50)
   })
 
   it('получение размера радиуса второй линии', () => {
-    expect(getDonutRadius(MAIN_RADIUS, 1, COUNT_LINES)).toEqual(474)
+    const received = getDonutRadius({
+      mainRadius: MAIN_RADIUS,
+      index: 1,
+      circlesCount: COUNT_LINES,
+      chartSize: SIZE,
+    })
+
+    expect(received).toEqual(36)
   })
 
   it('получение размера радиуса третьей линии', () => {
-    expect(getDonutRadius(MAIN_RADIUS, 2, COUNT_LINES)).toEqual(448)
+    const received = getDonutRadius({
+      mainRadius: MAIN_RADIUS,
+      index: 2,
+      circlesCount: COUNT_LINES,
+      chartSize: SIZE,
+    })
+
+    expect(received).toEqual(22)
   })
 })
 

--- a/src/__private__/components/CoreDonutChart/helpers.ts
+++ b/src/__private__/components/CoreDonutChart/helpers.ts
@@ -23,16 +23,16 @@ export type GetMinChartSize = (
 
 export type SortValue = (prev: DataItem, next: DataItem) => number
 
-export const donutSize: Record<number, number> = {
-  1: 18,
-  2: 14,
-  3: 10,
+export const donutSizeInPercent: Record<number, number> = {
+  1: 0.12,
+  2: 0.1,
+  3: 0.08,
 }
 
-export const paddingBetweenDonuts: Record<number, number> = {
+export const paddingBetweenDonutsInPercent: Record<number, number> = {
   1: 0,
-  2: 12,
-  3: 16,
+  2: 0.08,
+  3: 0.06,
 }
 
 export const isHalfDonutHorizontal = (halfDonut?: HalfDonut) => {
@@ -43,8 +43,8 @@ export const isHalfDonutVertical = (halfDonut?: HalfDonut) => {
   return halfDonut === 'right' || halfDonut === 'left'
 }
 
-export const getPadding = (countLines: number) => {
-  return paddingBetweenDonuts[countLines]
+export const getPadding = (circlesCount: number, chartSize: number) => {
+  return chartSize * paddingBetweenDonutsInPercent[circlesCount]
 }
 
 export const getChartSize = ({
@@ -67,16 +67,25 @@ export const getChartSize = ({
   return Math.min(width, height)
 }
 
-export const getSizeDonut = (
-  countLines: number,
-  isExistTextData?: boolean,
-  halfDonut?: HalfDonut
-) => {
-  return halfDonut || isExistTextData ? 16 : donutSize[countLines]
+export const getSizeDonut = (circlesCount: number, chartSize: number) => {
+  return chartSize * donutSizeInPercent[circlesCount]
 }
 
-export const getDonutRadius = (mainRadius: number, index: number, countLines: number) => {
-  return mainRadius - (getSizeDonut(countLines) + getPadding(countLines)) * index
+export const getDonutRadius = ({
+  mainRadius,
+  index,
+  circlesCount,
+  chartSize,
+}: {
+  mainRadius: number
+  index: number
+  circlesCount: number
+  chartSize: number
+}) => {
+  return (
+    mainRadius -
+    (getSizeDonut(circlesCount, chartSize) + getPadding(circlesCount, chartSize)) * index
+  )
 }
 
 export const defaultGetCirclesCount: GetCirclesCount = data => {


### PR DESCRIPTION
## Описание задачи

Раньше в пончике размеры линий были статические, в соответствии с новыми требованиями, размеры линий должны расчитываться на основе размера контейнера пончика.

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [x] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются переменные из UI-kit
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](https://consta-widgets.consta.vercel.app/?path=/docs/common-develop-commits-style--page)
