### PR TITLE
feat(components): добавлена возможность расчитывать минимальный размер DonutChart на основе контента

### DIFF
--- a/src/DonutChart/DonutChart.tsx
+++ b/src/DonutChart/DonutChart.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef, HTMLAttributes } from 'react'
 
 import { CoreDonutChart } from '@/__private__/components/CoreDonutChart'
-import { Data as DonutData, SortValue } from '@/__private__/components/CoreDonutChart/helpers'
-import { HalfDonut } from '@/__private__/components/CoreDonutChart/CoreDonutChartPie/CoreDonutChartPie'
+import { DonutDataItem, SortValue } from '@/__private__/components/CoreDonutChart/helpers'
+import { HalfDonut } from '@/__private__/components/CoreDonutChart/helpers'
 import { FormatValue } from '@/__private__/types'
 import { cn } from '@/__private__/utils/bem'
 import { Legend } from '@/Legend/Legend'
@@ -13,7 +13,7 @@ import './DonutChart.css'
 const cnDonutChart = cn('DonutChart')
 
 type Props = HTMLAttributes<HTMLDivElement> & {
-  data: readonly DonutData[]
+  data: readonly DonutDataItem[]
   value?: string
   label?: string
   halfDonut?: HalfDonut

--- a/src/DonutChart/__stories__/DonutChart.stories.tsx
+++ b/src/DonutChart/__stories__/DonutChart.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { object, select, text } from '@storybook/addon-knobs'
 
 import { defaultSortValue, SortValue } from '@/__private__/components/CoreDonutChart/helpers'
-import { halvesDonut } from '@/__private__/components/CoreDonutChart/CoreDonutChartPie/CoreDonutChartPie'
+import { halvesDonut } from '@/__private__/components/CoreDonutChart/helpers'
 import {
   createMetadata,
   createStory,

--- a/src/DonutChart/__tests__/helpers.ts
+++ b/src/DonutChart/__tests__/helpers.ts
@@ -1,4 +1,4 @@
-import { Data } from '@/__private__/components/CoreDonutChart/helpers'
+import { DonutDataItem } from '@/__private__/components/CoreDonutChart/helpers'
 
 import {
   DUMMY_ARC_NAME,
@@ -32,7 +32,7 @@ describe('filterComputedData', () => {
 })
 
 describe('getComputedData', () => {
-  const BASE_ITEMS: readonly Data[] = [
+  const BASE_ITEMS: readonly DonutDataItem[] = [
     {
       name: 'Item 1',
       color: 'red',

--- a/src/DonutChart/helpers.ts
+++ b/src/DonutChart/helpers.ts
@@ -1,12 +1,11 @@
-import { Data } from '@/__private__/components/CoreDonutChart/helpers'
-import { DataItem } from '@/__private__/components/CoreDonutChart/CoreDonutChartPie/CoreDonutChartPie'
+import { ArcDataItem, DonutDataItem } from '@/__private__/components/CoreDonutChart/helpers'
 
 export const DUMMY_ARC_NAME = '@arc:empty'
 
 export const legendPositions = ['top', 'right', 'bottom', 'left'] as const
 export type LegendPosition = typeof legendPositions[number]
 
-export const getTotalByCircle = (circles: readonly Data[]) => {
+export const getTotalByCircle = (circles: readonly DonutDataItem[]) => {
   return circles.reduce<readonly number[]>(
     (acc, insetArray) => insetArray.values.map((value, index) => acc[index] + (value ?? 0)),
     new Array(circles.length).fill(0)
@@ -20,7 +19,7 @@ export const getDiffsByTotalFromCircles = (totals: readonly number[], sums: read
   })
 }
 
-export const getComputedData = (circles: readonly Data[], sums?: readonly number[]) => {
+export const getComputedData = (circles: readonly DonutDataItem[], sums?: readonly number[]) => {
   if (!sums || sums.length === 0) {
     return circles
   }
@@ -35,7 +34,7 @@ export const getComputedData = (circles: readonly Data[], sums?: readonly number
   })
 }
 
-export const filterComputedData = (item: DataItem) => {
+export const filterComputedData = (item: ArcDataItem) => {
   return item.name !== DUMMY_ARC_NAME
 }
 

--- a/src/__private__/components/CoreDonutChart/CoreDonutChart.css
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChart.css
@@ -50,11 +50,6 @@
   &-Graph {
     position: absolute;
 
-    width: 100%;
-    max-width: 100%;
-    height: 100%;
-    max-height: 100%;
-
     &:not(&_half_bottom) {
       top: 0;
     }

--- a/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
@@ -99,9 +99,9 @@ export const CoreDonutChart: React.FC<Props> = ({
   const minChartSize = getMinChartSize(circlesCount, showText, halfDonut)
   const isTooltipVisible = Boolean(tooltipData.length)
   const arcRadiuses = getArcRadiuses({ mainRadius, circlesCount, sizeDonut, chartSize: size })
-  const values = getValues(data, circlesCount)
+  const values = getValues({ data, circlesCount, sortValue })
   const isTextVisible = values.length === 1 && showText
-  const piesData = values.map(item => getPieData(item, sortValue, halfDonut))
+  const piesData = values.map(item => getPieData(item, halfDonut))
   const rendersArc = arcRadiuses.map(getRenderArc)
 
   const handleMouseOver = showTooltip

--- a/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
@@ -155,6 +155,8 @@ export const CoreDonutChart: React.FC<Props> = ({
       )}
       <svg
         className={cnCoreDonutChart('Graph', { half: halfDonut ?? 'none' })}
+        width={svgWidth}
+        height={svgHeight}
         viewBox={viewBox}
         onMouseMove={handleMouseMove}
       >

--- a/src/__private__/components/CoreDonutChart/CoreDonutChartPie/CoreDonutChartPie.tsx
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChartPie/CoreDonutChartPie.tsx
@@ -1,148 +1,52 @@
-import React from 'react'
+import React, { forwardRef, SVGAttributes } from 'react'
 
-import * as d3 from 'd3'
+import { Arc, PieArcDatum } from 'd3-shape'
 
 import { cn } from '@/__private__/utils/bem'
 
-import { SortValue } from '../helpers'
+import {
+  ArcDataItem,
+  EMPTY_PIE_ARC_DATUM,
+  getArcAnglesByHalfDonut,
+  HalfDonut,
+  isEmptyPieArcDatum,
+} from '../helpers'
 
 import './CoreDonutChartPie.css'
 
 const cnCoreDonutChartPie = cn('CoreDonutChartPie')
 
-export type DataItem = {
-  value: number
-  color: string
-  name: string
-  showValue?: number
-}
+type MainElementProps = Omit<SVGAttributes<SVGGElement>, 'onMouseOver'>
 
-export type Data = readonly DataItem[]
-
-export const halvesDonut = ['top', 'left', 'right', 'bottom'] as const
-
-export type HalfDonut = typeof halvesDonut[number]
-
-type Props = {
-  data: Data
-  innerRadius: number
-  outerRadius: number
-  handleMouseOver: (data: Data) => void
-  handleMouseOut: () => void
-  isTooltipVisible: boolean
-  sortValue: SortValue | null
+type Props = MainElementProps & {
+  data: ReadonlyArray<PieArcDatum<ArcDataItem>>
+  renderArc: Arc<unknown, PieArcDatum<ArcDataItem>>
+  isTransparent: boolean
   halfDonut?: HalfDonut
+  onMouseOver: (data: ReadonlyArray<PieArcDatum<ArcDataItem>>) => void
 }
 
-/**
- * Отступ между D3.arc элементами, указывается в пикселях.
- */
-const ARC_PAD = 1
-const ARC_RADIUS = 100
-
-const fullCircleAngle = {
-  startAngle: 0,
-  endAngle: 2 * Math.PI,
+const renderPath = (
+  renderArc: Arc<unknown, PieArcDatum<ArcDataItem>>,
+  item: PieArcDatum<ArcDataItem>,
+  idx?: number
+) => {
+  return <path key={idx} d={renderArc(item) || undefined} fill={item.data.color} />
 }
 
-const getAnglesByHalfDonut = (halfDonut?: HalfDonut) => {
-  switch (halfDonut) {
-    case 'top': {
-      return {
-        startAngle: Math.PI * 1.5,
-        endAngle: Math.PI * 0.5,
-      }
-    }
-    case 'right': {
-      return {
-        startAngle: 2 * Math.PI,
-        endAngle: Math.PI,
-      }
-    }
-    case 'bottom': {
-      return {
-        startAngle: Math.PI * -0.5,
-        endAngle: Math.PI * 0.5,
-      }
-    }
-    case 'left': {
-      return {
-        startAngle: 0,
-        endAngle: Math.PI,
-      }
-    }
-    default: {
-      return fullCircleAngle
-    }
-  }
-}
-
-const isEmpty = (pieData: ReadonlyArray<Omit<DataItem, 'color' | 'name'>>) => {
-  return pieData.map(pieDatum => pieDatum.value).every(value => value === 0)
-}
-
-export const Donut: React.FC<Props> = ({
-  data,
-  innerRadius,
-  outerRadius,
-  handleMouseOver,
-  handleMouseOut,
-  isTooltipVisible,
-  sortValue,
-  halfDonut,
-}) => {
-  const { startAngle, endAngle } = getAnglesByHalfDonut(halfDonut)
-
-  const pieData = d3
-    .pie<DataItem>()
-    .sort((prev, next) => (sortValue ? sortValue(prev, next) : 0))
-    .startAngle(startAngle)
-    .endAngle(endAngle)
-    .value(d => d.value)([...data])
-
-  const arc = d3
-    .arc<d3.PieArcDatum<DataItem>>()
-    .innerRadius(innerRadius)
-    .outerRadius(outerRadius)
-    /**
-     * padAngle для каждого D3.arc расчитывается по формуле:
-     *
-     * `padRadius * [переданное значение]`
-     *
-     * https://github.com/d3/d3-shape#arc_padAngle
-     */
-    .padAngle(ARC_PAD / ARC_RADIUS)
-    /**
-     * Указывается специфичный радиус для правильного расчета `padAngle`, если
-     * не указать значение или указать `null`, то расчет этого параметра
-     * производится по формуле:
-     *
-     * `sqrt(innerRadius * innerRadius + outerRadius * outerRadius)`
-     *
-     * Т.е. для каждого вложенного компонента Donut, размер отступа будет меньше
-     * чем у предыдущего, чтобы это исправить указываем фиксированное значение
-     * которое исправляет расчеты.
-     *
-     * https://github.com/d3/d3-shape#arc_padRadius
-     */
-    .padRadius(ARC_RADIUS)
+export const CoreDonutChartPie = forwardRef<SVGGElement, Props>((props, ref) => {
+  const { data, renderArc, isTransparent, halfDonut, onMouseOver, ...mainElementProps } = props
 
   return (
     <g
-      className={cnCoreDonutChartPie({ isTransparent: isTooltipVisible })}
-      onMouseOver={() => handleMouseOver(data)}
-      onMouseOut={handleMouseOut}
+      {...mainElementProps}
+      ref={ref}
+      className={cnCoreDonutChartPie({ isTransparent })}
+      onMouseOver={() => onMouseOver(data)}
     >
-      {isEmpty(pieData) ? (
-        <path
-          d={arc({ ...pieData[0], ...fullCircleAngle }) || undefined}
-          fill="var(--color-bg-ghost)"
-        />
-      ) : (
-        pieData.map((pieDatum, idx) => (
-          <path key={idx} d={arc(pieDatum) || undefined} fill={pieDatum.data.color} />
-        ))
-      )}
+      {isEmptyPieArcDatum(data)
+        ? renderPath(renderArc, { ...EMPTY_PIE_ARC_DATUM, ...getArcAnglesByHalfDonut(halfDonut) })
+        : data.map((item, idx) => renderPath(renderArc, item, idx))}
     </g>
   )
-}
+})

--- a/src/__private__/components/CoreDonutChart/CoreDonutChartText/CoreDonutChartText.tsx
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChartText/CoreDonutChartText.tsx
@@ -4,7 +4,7 @@ import { Textfit } from '@evless/react-textfit'
 
 import { cn } from '@/__private__/utils/bem'
 
-import { HalfDonut } from '../CoreDonutChartPie/CoreDonutChartPie'
+import { HalfDonut } from '../helpers'
 
 import {
   getContainerPadding,

--- a/src/__private__/components/CoreDonutChart/CoreDonutChartText/helpers.ts
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChartText/helpers.ts
@@ -1,5 +1,5 @@
 import { isHalfDonutHorizontal, isHalfDonutVertical } from '../helpers'
-import { HalfDonut } from '../CoreDonutChartPie/CoreDonutChartPie'
+import { HalfDonut } from '../helpers'
 
 type HalfDonutDirection = 'horizontal' | 'vertical' | 'none'
 

--- a/src/__private__/components/CoreDonutChart/__tests__/helpers.test.ts
+++ b/src/__private__/components/CoreDonutChart/__tests__/helpers.test.ts
@@ -106,36 +106,8 @@ describe('defaultGetCirclesCount', () => {
 })
 
 describe('defaultGetMinChartSize', () => {
-  it('получение минимального размера необрезанного графика с 1 линией без текста', () => {
-    expect(defaultGetMinChartSize(1, false)).toEqual(0)
-  })
-
-  it('получение минимального размера необрезанного графика с 2 линиями без текста', () => {
-    expect(defaultGetMinChartSize(2, false)).toEqual(0)
-  })
-
-  it('получение минимального размера необрезанного графика с 3 линиями без текста', () => {
-    expect(defaultGetMinChartSize(3, false)).toEqual(0)
-  })
-
-  it('получение минимального размера необрезанного графика с 1 линией с текстом', () => {
-    expect(defaultGetMinChartSize(1, true)).toEqual(100)
-  })
-
-  it('получение минимального размера необрезанного графика с 2 линиями с текстом', () => {
-    expect(defaultGetMinChartSize(2, true)).toEqual(0)
-  })
-
-  it('получение минимального размера необрезанного графика с 3 линиями с текстом', () => {
-    expect(defaultGetMinChartSize(3, true)).toEqual(0)
-    expect(defaultGetMinChartSize(3, false)).toEqual(0)
-  })
-
-  it('получение минимального размера обрезанного графика с 1 линией и текстом', () => {
-    expect(defaultGetMinChartSize(1, true, 'top')).toEqual(0)
-    expect(defaultGetMinChartSize(1, true, 'right')).toEqual(0)
-    expect(defaultGetMinChartSize(1, true, 'bottom')).toEqual(0)
-    expect(defaultGetMinChartSize(1, true, 'left')).toEqual(0)
+  it('получение минимального размера графика', () => {
+    expect(defaultGetMinChartSize(1, false)).toEqual(100)
   })
 })
 

--- a/src/__private__/components/CoreDonutChart/__tests__/helpers.test.ts
+++ b/src/__private__/components/CoreDonutChart/__tests__/helpers.test.ts
@@ -3,6 +3,7 @@ import { createArrayOfIndexes } from '@consta/widgets-utils/lib/array'
 import {
   defaultGetCirclesCount,
   defaultGetMinChartSize,
+  defaultSortValue,
   getArcRadiuses,
   getChartSize,
   getDonutMaxMinSizeRect,
@@ -140,31 +141,31 @@ describe('defaultGetMinChartSize', () => {
 
 describe('getValues', () => {
   it('получает данные для одного кольца', () => {
-    const received = getValues(
-      [
+    const received = getValues({
+      data: [
         {
           color: 'red',
           name: 'Group 1',
           values: [1, 2, 3],
         },
       ],
-      1
-    )
+      circlesCount: 1,
+    })
 
     expect(received).toEqual([[{ color: 'red', name: 'Group 1', value: 1 }]])
   })
 
   it('Получает данные для трех колец', () => {
-    const received = getValues(
-      [
+    const received = getValues({
+      data: [
         {
           color: 'red',
           name: 'Group 1',
           values: [1, 2, 3],
         },
       ],
-      3
-    )
+      circlesCount: 3,
+    })
 
     expect(received).toEqual([
       [{ color: 'red', name: 'Group 1', value: 1 }],
@@ -174,21 +175,58 @@ describe('getValues', () => {
   })
 
   it('Получает данные для трех колец, если исходные данные пустые', () => {
-    const received = getValues([], 3)
+    const received = getValues({
+      data: [],
+      circlesCount: 3,
+    })
 
     expect(received).toEqual([[], [], []])
+  })
+
+  it('Получает данные для трех колец с сортировкой', () => {
+    const received = getValues({
+      data: [
+        {
+          color: 'red',
+          name: 'Group 1',
+          values: [4, 5, 6],
+        },
+        {
+          color: 'blue',
+          name: 'Group 2',
+          values: [1, 2, 3],
+        },
+      ],
+      circlesCount: 3,
+      sortValue: defaultSortValue,
+    })
+
+    expect(received).toEqual([
+      [
+        { color: 'red', name: 'Group 1', value: 4 },
+        { color: 'blue', name: 'Group 2', value: 1 },
+      ],
+      [
+        { color: 'red', name: 'Group 1', value: 5 },
+        { color: 'blue', name: 'Group 2', value: 2 },
+      ],
+      [
+        { color: 'red', name: 'Group 1', value: 6 },
+        { color: 'blue', name: 'Group 2', value: 3 },
+      ],
+    ])
   })
 })
 
 describe('getPieData', () => {
   it('получение данных для кольца, если исходные данные пустые', () => {
-    const received = getPieData([], null)
+    const received = getPieData([])
 
     expect(received).toEqual([])
   })
 
   it('получение данных для кольца', () => {
-    const received = getPieData([{ color: 'red', name: 'Group 1', value: null }], null)
+    const received = getPieData([{ color: 'red', name: 'Group 1', value: null }])
 
     expect(received).toEqual([
       {

--- a/src/__private__/components/CoreDonutChart/helpers.ts
+++ b/src/__private__/components/CoreDonutChart/helpers.ts
@@ -1,31 +1,57 @@
 import { CSSProperties } from 'react'
 
-import { DataItem, HalfDonut } from './CoreDonutChartPie/CoreDonutChartPie'
+import { createArrayOfIndexes } from '@consta/widgets-utils/lib/array'
+import { isNotNil } from '@consta/widgets-utils/lib/type-guards'
+import { arc, pie, PieArcDatum } from 'd3-shape'
 
-export const MAX_CIRCLES_TO_RENDER = 3
+export const halvesDonut = ['top', 'right', 'bottom', 'left'] as const
+export type HalfDonut = typeof halvesDonut[number]
 
-export const minChartSize: Record<number, number> = {
-  1: 50,
-  2: 100,
-  3: 150,
-}
-
-export type Data = {
+export type DonutDataItem = {
   name: string
   color: string
   values: ReadonlyArray<number | null>
 }
-export type GetCirclesCount = (data: readonly Data[]) => number
 
-export type GetMinChartSize = (
-  circlesCount: number,
-  isExistTextData?: boolean,
-  halfDonut?: HalfDonut
-) => number
+export type ArcDataItem = {
+  value: number | null
+  color: string
+  name: string
+}
+
+export type SortValue = (prev: ArcDataItem, next: ArcDataItem) => number
 
 export type LimitSizeSide = 'width' | 'height'
 
-export type SortValue = (prev: DataItem, next: DataItem) => number
+export type ArcRadius = {
+  inner: number
+  outer: number
+}
+
+export const MAX_CIRCLES_TO_RENDER = 3
+
+/**
+ * Отступ между D3.arc элементами, указывается в пикселях.
+ */
+export const ARC_PAD = 1
+export const ARC_RADIUS = 100
+export const ARC_FULL_ANGLE = {
+  startAngle: 0,
+  endAngle: 2 * Math.PI,
+}
+
+export const EMPTY_PIE_ARC_DATUM: PieArcDatum<ArcDataItem> = {
+  data: {
+    color: 'var(--color-bg-ghost)',
+    name: '',
+    value: null,
+  },
+  endAngle: 0,
+  index: 0,
+  padAngle: 0,
+  startAngle: 0,
+  value: 0,
+}
 
 export const donutSizeInPercent: Record<number, number> = {
   1: 0.12,
@@ -38,6 +64,14 @@ export const paddingBetweenDonutsInPercent: Record<number, number> = {
   2: 0.08,
   3: 0.06,
 }
+
+export type GetCirclesCount = (data: readonly DonutDataItem[]) => number
+
+export type GetMinChartSize = (
+  circlesCount: number,
+  isExistTextData?: boolean,
+  halfDonut?: HalfDonut
+) => number
 
 export const isHalfDonutHorizontal = (halfDonut?: HalfDonut) => {
   return halfDonut === 'top' || halfDonut === 'bottom'
@@ -106,17 +140,134 @@ export const defaultGetMinChartSize: GetMinChartSize = (
   halfDonut?: HalfDonut
 ) => {
   if (countLines === 1 && isExistTextData && !halfDonut) {
-    return 96
+    return 100
   }
 
-  if (countLines === 1 && isExistTextData && halfDonut) {
-    return 170
-  }
+  return 0
+}
 
-  return minChartSize[countLines]
+export const getArcAnglesByHalfDonut = (halfDonut?: HalfDonut) => {
+  switch (halfDonut) {
+    case 'top': {
+      return {
+        startAngle: Math.PI * 1.5,
+        endAngle: Math.PI * 0.5,
+      }
+    }
+    case 'right': {
+      return {
+        startAngle: 2 * Math.PI,
+        endAngle: Math.PI,
+      }
+    }
+    case 'bottom': {
+      return {
+        startAngle: Math.PI * -0.5,
+        endAngle: Math.PI * 0.5,
+      }
+    }
+    case 'left': {
+      return {
+        startAngle: 0,
+        endAngle: Math.PI,
+      }
+    }
+    default: {
+      return ARC_FULL_ANGLE
+    }
+  }
+}
+
+type GetArcRadiusesParams = {
+  mainRadius: number
+  circlesCount: number
+  sizeDonut: number
+  chartSize: number
+}
+
+export const getArcRadiuses = (params: GetArcRadiusesParams): readonly ArcRadius[] => {
+  return createArrayOfIndexes(params.circlesCount).map(index => {
+    const outer = getDonutRadius({
+      index,
+      chartSize: params.chartSize,
+      circlesCount: params.circlesCount,
+      mainRadius: params.mainRadius,
+    })
+    const inner = outer - params.sizeDonut
+
+    return { outer, inner }
+  })
+}
+
+export const getPieData = (
+  data: readonly ArcDataItem[],
+  sortValue: SortValue | null,
+  halfDonut?: HalfDonut
+) => {
+  const { startAngle, endAngle } = getArcAnglesByHalfDonut(halfDonut)
+
+  const dataGenerator = pie<ArcDataItem>()
+    .sort((prev, next) => (sortValue ? sortValue(prev, next) : 0))
+    .startAngle(startAngle)
+    .endAngle(endAngle)
+    .value(item => item.value ?? 0)
+
+  return dataGenerator([...data])
+}
+
+export const getRenderArc = (radius: ArcRadius) => {
+  return (
+    arc<unknown, PieArcDatum<ArcDataItem>>()
+      .innerRadius(radius.inner)
+      .outerRadius(radius.outer)
+      /**
+       * padAngle для каждого D3.arc расчитывается по формуле:
+       *
+       * `padRadius * [переданное значение]`
+       *
+       * https://github.com/d3/d3-shape#arc_padAngle
+       */
+      .padAngle(ARC_PAD / ARC_RADIUS)
+      /**
+       * Указывается специфичный радиус для правильного расчета `padAngle`, если
+       * не указать значение или указать `null`, то расчет этого параметра
+       * производится по формуле:
+       *
+       * `sqrt(innerRadius * innerRadius + outerRadius * outerRadius)`
+       *
+       * Т.е. для каждого вложенного компонента Donut, размер отступа будет меньше
+       * чем у предыдущего, чтобы это исправить указываем фиксированное значение
+       * которое исправляет расчеты.
+       *
+       * https://github.com/d3/d3-shape#arc_padRadius
+       */
+      .padRadius(ARC_RADIUS)
+  )
+}
+
+export const isEmptyPieArcDatum = (value: ReadonlyArray<PieArcDatum<ArcDataItem>>) => {
+  return value.every(item => item.value === 0)
+}
+
+export const getValues = (data: readonly DonutDataItem[], circlesCount: number) => {
+  const arraysOfDataItems = data.map(item =>
+    item.values.slice(0, circlesCount).map(value => ({
+      color: item.color,
+      name: item.name,
+      value,
+    }))
+  )
+
+  return createArrayOfIndexes(circlesCount).map((_, index) =>
+    arraysOfDataItems.map(dataItems => dataItems[index])
+  )
 }
 
 export const defaultSortValue: SortValue = (prev, next) => {
+  if (!isNotNil(prev.value) || !isNotNil(next.value)) {
+    return 0
+  }
+
   return next.value - prev.value
 }
 

--- a/src/__private__/components/CoreDonutChart/helpers.ts
+++ b/src/__private__/components/CoreDonutChart/helpers.ts
@@ -134,16 +134,8 @@ export const defaultGetCirclesCount: GetCirclesCount = data => {
   return Math.min(Math.max(...data.map(i => i.values.length)), MAX_CIRCLES_TO_RENDER)
 }
 
-export const defaultGetMinChartSize: GetMinChartSize = (
-  countLines: number,
-  isExistTextData?: boolean,
-  halfDonut?: HalfDonut
-) => {
-  if (countLines === 1 && isExistTextData && !halfDonut) {
-    return 100
-  }
-
-  return 0
+export const defaultGetMinChartSize: GetMinChartSize = () => {
+  return 100
 }
 
 export const getArcAnglesByHalfDonut = (halfDonut?: HalfDonut) => {
@@ -252,15 +244,17 @@ type GetValuesParams = {
 }
 
 export const getValues = ({ circlesCount, data, sortValue }: GetValuesParams) => {
+  const indexes = createArrayOfIndexes(circlesCount)
+
   const arraysOfDataItems = data.map(item =>
-    item.values.slice(0, circlesCount).map(value => ({
+    indexes.map((_, index) => ({
       color: item.color,
       name: item.name,
-      value,
+      value: item.values[index] ?? null,
     }))
   )
 
-  return createArrayOfIndexes(circlesCount).map((_, index) =>
+  return indexes.map((_, index) =>
     arraysOfDataItems
       .map(dataItems => dataItems[index])
       .sort((prev, next) => (sortValue ? sortValue(prev, next) : 0))
@@ -294,13 +288,20 @@ export const getDonutMaxMinSizeRect = ({
 }: GetSizeRectParams): CSSProperties => {
   const halfWidth = width / 2
   const halfHeight = height / 2
-  const maxWidth = limitSizeSide === 'width' ? height : undefined
-  const maxHeight = limitSizeSide === 'height' ? width : undefined
-
-  return {
+  const base = {
     minWidth: isHalfVertical ? halfHeight : minSize,
-    maxWidth: isHalfVertical ? halfHeight : maxWidth,
+    maxWidth: isHalfVertical ? halfHeight : undefined,
     minHeight: isHalfHorizontal ? halfWidth : minSize,
-    maxHeight: isHalfHorizontal ? halfWidth : maxHeight,
+    maxHeight: isHalfHorizontal ? halfWidth : undefined,
   }
+
+  if (!isHalfHorizontal && !isHalfVertical) {
+    return {
+      ...base,
+      maxWidth: limitSizeSide === 'width' ? height : undefined,
+      maxHeight: limitSizeSide === 'height' ? width : undefined,
+    }
+  }
+
+  return base
 }

--- a/src/__private__/components/CoreDonutChart/helpers.ts
+++ b/src/__private__/components/CoreDonutChart/helpers.ts
@@ -199,15 +199,11 @@ export const getArcRadiuses = (params: GetArcRadiusesParams): readonly ArcRadius
   })
 }
 
-export const getPieData = (
-  data: readonly ArcDataItem[],
-  sortValue: SortValue | null,
-  halfDonut?: HalfDonut
-) => {
+export const getPieData = (data: readonly ArcDataItem[], halfDonut?: HalfDonut) => {
   const { startAngle, endAngle } = getArcAnglesByHalfDonut(halfDonut)
 
   const dataGenerator = pie<ArcDataItem>()
-    .sort((prev, next) => (sortValue ? sortValue(prev, next) : 0))
+    .sort(null)
     .startAngle(startAngle)
     .endAngle(endAngle)
     .value(item => item.value ?? 0)
@@ -249,7 +245,13 @@ export const isEmptyPieArcDatum = (value: ReadonlyArray<PieArcDatum<ArcDataItem>
   return value.every(item => item.value === 0)
 }
 
-export const getValues = (data: readonly DonutDataItem[], circlesCount: number) => {
+type GetValuesParams = {
+  data: readonly DonutDataItem[]
+  circlesCount: number
+  sortValue?: SortValue | null
+}
+
+export const getValues = ({ circlesCount, data, sortValue }: GetValuesParams) => {
   const arraysOfDataItems = data.map(item =>
     item.values.slice(0, circlesCount).map(value => ({
       color: item.color,
@@ -259,7 +261,9 @@ export const getValues = (data: readonly DonutDataItem[], circlesCount: number) 
   )
 
   return createArrayOfIndexes(circlesCount).map((_, index) =>
-    arraysOfDataItems.map(dataItems => dataItems[index])
+    arraysOfDataItems
+      .map(dataItems => dataItems[index])
+      .sort((prev, next) => (sortValue ? sortValue(prev, next) : 0))
   )
 }
 


### PR DESCRIPTION
## Описание изменений

* упрощен компонент CoreDonutChartPie;
* упрощен компонент CoreDonutChart;
* генерация и предрасчет размеров вынесены в отдельные хелперы;
* добавлены тесты на хелперы;
* с учетом переноса расчетов в сам CoreDonutChart теперь можно считать размер подписей к дугам и прибавлять к минимальному размеру пончика что будет довольно удобно при дальнейшей разработке;

## Чек-лист

- [x] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [x] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются переменные из UI-kit
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [x] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](https://consta-widgets.consta.vercel.app/?path=/docs/common-develop-commits-style--page)
