### PR TITLE
feat(components): добавлена возможность выводить виджет Legend рядом с DonutChart

### DIFF
--- a/src/DonutChart/DonutChart.css
+++ b/src/DonutChart/DonutChart.css
@@ -1,0 +1,54 @@
+.cw--DonutChart {
+  display: flex;
+
+  width: 100%;
+  height: 100%;
+
+  &_legendPosition_top {
+    flex-direction: column;
+  }
+
+  &_legendPosition_right {
+    flex-direction: row-reverse;
+    justify-content: flex-end;
+  }
+
+  &_legendPosition_bottom {
+    flex-direction: column-reverse;
+    justify-content: flex-end;
+  }
+
+  &_legendPosition_left {
+    flex-direction: row;
+  }
+
+  &-Legend {
+    flex-shrink: 0;
+  }
+
+  &_legendPosition_top &-Legend {
+    margin-bottom: var(--space-4xl);
+  }
+
+  &_legendPosition_right &-Legend {
+    margin-left: var(--space-4xl);
+  }
+
+  &_legendPosition_bottom &-Legend {
+    margin-top: var(--space-4xl);
+  }
+
+  &_legendPosition_left &-Legend {
+    margin-right: var(--space-4xl);
+  }
+
+  &_legendPosition_top &-Legend,
+  &_legendPosition_bottom &-Legend {
+    width: 100%;
+  }
+
+  &_legendPosition_right &-Legend,
+  &_legendPosition_left &-Legend {
+    max-width: 60%;
+  }
+}

--- a/src/DonutChart/DonutChart.tsx
+++ b/src/DonutChart/DonutChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef, HTMLAttributes } from 'react'
 
 import { CoreDonutChart } from '@/__private__/components/CoreDonutChart'
 import {
@@ -9,32 +9,56 @@ import {
 import { HalfDonut } from '@/__private__/components/CoreDonutChart/CoreDonutChartPie/CoreDonutChartPie'
 import { Data as DonutTextData } from '@/__private__/components/CoreDonutChart/CoreDonutChartText/CoreDonutChartText'
 import { FormatValue } from '@/__private__/types'
+import { cn } from '@/__private__/utils/bem'
+import { Legend } from '@/Legend/Legend'
 
-import { filterComputedData, getComputedData } from './helpers'
+import { filterComputedData, getComputedData, getLimitSizeSide, LegendPosition } from './helpers'
+import './DonutChart.css'
 
-type Props = {
+const cnDonutChart = cn('DonutChart')
+
+type Props = HTMLAttributes<HTMLDivElement> & {
   data: readonly DonutData[]
   textData?: DonutTextData
   halfDonut?: HalfDonut
   valueSize?: number
   sums?: readonly number[]
+  legendPosition?: LegendPosition
   formatValueForTooltip?: FormatValue
   sortValue?: SortValue | null
 }
 
-export const DonutChart: React.FC<Props> = ({ data, sums, halfDonut, ...rest }) => {
+export const DonutChart = forwardRef<HTMLDivElement, Props>((props, ref) => {
+  const { data, halfDonut, legendPosition, sums, ...rest } = props
+
+  const legendItems = data.map(item => ({ text: item.name, color: item.color }))
+
   return (
-    <CoreDonutChart
-      {...rest}
-      data={getComputedData(data, sums)}
-      halfDonut={halfDonut}
-      titlePosition={halfDonut === 'bottom' ? 'bottom' : 'top'}
-      textPaddingFromBorder={halfDonut ? 8 : 0}
-      showTitle={Boolean(halfDonut)}
-      showSubBlock={isHalfDonutVertical(halfDonut)}
-      filterTooltipItem={filterComputedData}
-      showTooltip
-      showText
-    />
+    <div ref={ref} className={cnDonutChart({ legendPosition })}>
+      {legendPosition && (
+        <div className={cnDonutChart('Legend')}>
+          <Legend
+            items={legendItems}
+            direction={legendPosition === 'right' || legendPosition === 'left' ? 'column' : 'row'}
+            labelPosition="left"
+            size="m"
+            type="dot"
+          />
+        </div>
+      )}
+      <CoreDonutChart
+        {...rest}
+        limitSizeSide={getLimitSizeSide(legendPosition)}
+        data={getComputedData(data, sums)}
+        halfDonut={halfDonut}
+        titlePosition={halfDonut === 'bottom' ? 'bottom' : 'top'}
+        textPaddingFromBorder={halfDonut ? 8 : 0}
+        showTitle={Boolean(halfDonut)}
+        showSubBlock={isHalfDonutVertical(halfDonut)}
+        filterTooltipItem={filterComputedData}
+        showTooltip
+        showText
+      />
+    </div>
   )
-}
+})

--- a/src/DonutChart/__stories__/DonutChart.mdx
+++ b/src/DonutChart/__stories__/DonutChart.mdx
@@ -16,6 +16,10 @@ import {
   DonutChartHalfDonutBottom,
   DonutChartHalfDonutLeft,
   DonutChartHalfDonutRight,
+  DonutChartLegendTop,
+  DonutChartLegendRight,
+  DonutChartLegendBottom,
+  DonutChartLegendLeft,
 } from './examples/DonutChartExample'
 
 # DonutChart
@@ -125,6 +129,24 @@ formatValueForTooltip={v => `${v} км`}
 | --------------------------- | ---------------------------- |
 | <DonutChartHalfDonutLeft /> | <DonutChartHalfDonutRight /> |
 
+## Легенда
+
+**legendPosition="top"**
+
+<DonutChartLegendTop />
+
+**legendPosition="right"**
+
+<DonutChartLegendRight />
+
+**legendPosition="bottom"**
+
+<DonutChartLegendBottom />
+
+**legendPosition="left"**
+
+<DonutChartLegendLeft />
+
 ## Свойства
 
 | Свойство                            | Тип                                                      | По умолчанию                                 | Описание                                                                                                                                    |
@@ -136,6 +158,7 @@ formatValueForTooltip={v => `${v} км`}
 | [`formatValueForTooltip?`](#тултип) | `string`                                                 | -                                            | Формат значения в тултипе                                                                                                                   |
 | `sums?`                             | `readonly number[]`                                      | -                                            | Массив максимальных значений для окружности, если сумма всех дуг будет меньше появится заполнитель, иначе заполнитель не будет отображаться |
 | `sortValue?`                        | `((prev: DataItem, next: DataItem) => number)` \| `null` | `(prev: DataItem, next: DataItem) => number` | Метод сортировки значений, по умолчанию сортирует от большего к меньшему                                                                    |
+| `legendPosition?`                   | `'top', 'right', 'left', 'bottom'`                       | -                                            | Определяет необходимость отображения легенды, и ее положение относительно графика                                                           |
 
 ### DonutData
 

--- a/src/DonutChart/__stories__/DonutChart.stories.tsx
+++ b/src/DonutChart/__stories__/DonutChart.stories.tsx
@@ -13,6 +13,7 @@ import {
 import { FormatValue } from '@/__private__/types'
 
 import { DonutChart } from '..'
+import { legendPositions } from '../helpers'
 import { donutData } from '../__mocks__/data.mock'
 
 import mdx from './DonutChart.mdx'
@@ -40,6 +41,7 @@ const getKnobs = () => {
     }),
     halfDonut: optionalSelect('halfDonut', halvesDonut, undefined),
     sums: object('sums', []),
+    legendPosition: optionalSelect('legendPosition', legendPositions, undefined),
     formatValueForTooltip:
       formatsValueForTooltip[
         select('formatValueForTooltip', formattersKeysForTooltip, formattersKeysForTooltip[0])

--- a/src/DonutChart/__stories__/examples/DonutChartExample.tsx
+++ b/src/DonutChart/__stories__/examples/DonutChartExample.tsx
@@ -221,3 +221,27 @@ export const DonutChartHalfDonutRight = () => (
     <DonutChart data={donutData.data} halfDonut="right" />
   </Example>
 )
+
+export const DonutChartLegendTop = () => (
+  <Example width="200" height="300px">
+    <DonutChart data={donutData.data} legendPosition="top" />
+  </Example>
+)
+
+export const DonutChartLegendRight = () => (
+  <Example width="400px" height="200">
+    <DonutChart data={donutData.data} legendPosition="right" />
+  </Example>
+)
+
+export const DonutChartLegendBottom = () => (
+  <Example width="200" height="300px">
+    <DonutChart data={donutData.data} legendPosition="bottom" />
+  </Example>
+)
+
+export const DonutChartLegendLeft = () => (
+  <Example width="400px" height="200">
+    <DonutChart data={donutData.data} legendPosition="left" />
+  </Example>
+)

--- a/src/DonutChart/__tests__/helpers.ts
+++ b/src/DonutChart/__tests__/helpers.ts
@@ -5,6 +5,7 @@ import {
   filterComputedData,
   getComputedData,
   getDiffsByTotalFromCircles,
+  getLimitSizeSide,
   getTotalByCircle,
 } from '../helpers'
 
@@ -88,5 +89,30 @@ describe('getTotalByCircle', () => {
     ])
 
     expect(received).toEqual([11, 15, 18])
+  })
+})
+
+describe('getLimitSizeSide', () => {
+  const horizontalSides = ['top', 'bottom'] as const
+  const verticalSides = ['right', 'left'] as const
+
+  it('получение плоскости для ограничения размера, без легенды', () => {
+    const received = getLimitSizeSide()
+
+    expect(received).toEqual(undefined)
+  })
+
+  it('получение плоскости для ограничения размера, с легендой', () => {
+    horizontalSides.map(side => {
+      const received = getLimitSizeSide(side)
+
+      expect(received).toEqual('height')
+    })
+
+    verticalSides.map(side => {
+      const received = getLimitSizeSide(side)
+
+      expect(received).toEqual('width')
+    })
   })
 })

--- a/src/DonutChart/helpers.ts
+++ b/src/DonutChart/helpers.ts
@@ -3,6 +3,9 @@ import { DataItem } from '@/__private__/components/CoreDonutChart/CoreDonutChart
 
 export const DUMMY_ARC_NAME = '@arc:empty'
 
+export const legendPositions = ['top', 'right', 'bottom', 'left'] as const
+export type LegendPosition = typeof legendPositions[number]
+
 export const getTotalByCircle = (circles: readonly Data[]) => {
   return circles.reduce<readonly number[]>(
     (acc, insetArray) => insetArray.values.map((value, index) => acc[index] + (value ?? 0)),
@@ -34,4 +37,16 @@ export const getComputedData = (circles: readonly Data[], sums?: readonly number
 
 export const filterComputedData = (item: DataItem) => {
   return item.name !== DUMMY_ARC_NAME
+}
+
+export const getLimitSizeSide = (legendPosition?: LegendPosition) => {
+  if (!legendPosition) {
+    return
+  }
+
+  if (legendPosition === 'right' || legendPosition === 'left') {
+    return 'width'
+  }
+
+  return 'height'
 }

--- a/src/__private__/components/CoreDonutChart/CoreDonutChart.css
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChart.css
@@ -4,9 +4,7 @@
   overflow: hidden;
 
   width: 100%;
-  min-width: var(--min-size, 0);
   height: 100%;
-  min-height: var(--min-size, 0);
 
   &-Graph {
     position: absolute;

--- a/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
@@ -18,11 +18,13 @@ import {
   defaultSortValue,
   getChartSize,
   GetCirclesCount,
+  getDonutMaxMinSizeRect,
   getDonutRadius,
   GetMinChartSize,
   getSizeDonut,
   isHalfDonutHorizontal as getIsHalfDonutHorizontal,
   isHalfDonutVertical as getIsHalfDonutVertical,
+  LimitSizeSide,
   SortValue,
 } from './helpers'
 import './CoreDonutChart.css'
@@ -58,6 +60,7 @@ export type Props = {
   textPaddingFromBorder: number
   halfDonut?: HalfDonut
   valueSize?: number
+  limitSizeSide?: LimitSizeSide
   sortValue?: SortValue | null
   getCirclesCount?: GetCirclesCount
   getMinChartSize?: GetMinChartSize
@@ -76,6 +79,7 @@ export const CoreDonutChart: React.FC<Props> = ({
   textPaddingFromBorder,
   halfDonut,
   valueSize,
+  limitSizeSide,
   sortValue = defaultSortValue,
   getCirclesCount = defaultGetCirclesCount,
   getMinChartSize = defaultGetMinChartSize,
@@ -155,7 +159,14 @@ export const CoreDonutChart: React.FC<Props> = ({
       ref={ref}
       className={cnCoreDonutChart()}
       style={{
-        ['--min-size' as string]: `${minChartSize}px`,
+        ...getDonutMaxMinSizeRect({
+          height,
+          width,
+          minSize: minChartSize,
+          isHalfHorizontal: isHalfDonutHorizontal,
+          isHalfVertical: isHalfDonutVertical,
+          limitSizeSide,
+        }),
         ['--donut-width' as string]: `${sizeDonut}px`,
       }}
     >

--- a/src/__private__/components/CoreDonutChart/__tests__/helpers.test.ts
+++ b/src/__private__/components/CoreDonutChart/__tests__/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   defaultGetCirclesCount,
   defaultGetMinChartSize,
   getChartSize,
+  getDonutMaxMinSizeRect,
   getDonutRadius,
   getPadding,
   getSizeDonut,
@@ -138,5 +139,94 @@ describe('defaultGetMinChartSize', () => {
     expect(defaultGetMinChartSize(3, true, 'right')).toEqual(minChartSize[3])
     expect(defaultGetMinChartSize(3, true, 'bottom')).toEqual(minChartSize[3])
     expect(defaultGetMinChartSize(3, true, 'left')).toEqual(minChartSize[3])
+  })
+})
+
+describe('getDonutMaxMinSizeRect', () => {
+  it('получение стилей для минимального и максимального размера графика', () => {
+    const received = getDonutMaxMinSizeRect({
+      height: 100,
+      width: 100,
+      isHalfHorizontal: false,
+      isHalfVertical: false,
+      minSize: 50,
+    })
+
+    expect(received).toEqual({
+      minWidth: 50,
+      maxWidth: undefined,
+      minHeight: 50,
+      maxHeight: undefined,
+    })
+  })
+
+  it('получение стилей для минимального и максимального размера обрезанного по горизонтали графика', () => {
+    const received = getDonutMaxMinSizeRect({
+      height: 100,
+      width: 100,
+      isHalfHorizontal: true,
+      isHalfVertical: false,
+      minSize: 50,
+    })
+
+    expect(received).toEqual({
+      minWidth: 50,
+      maxWidth: undefined,
+      minHeight: 50,
+      maxHeight: 50,
+    })
+  })
+
+  it('получение стилей для минимального и максимального размера обрезанного по вертикале графика', () => {
+    const received = getDonutMaxMinSizeRect({
+      height: 100,
+      width: 100,
+      isHalfHorizontal: false,
+      isHalfVertical: true,
+      minSize: 50,
+    })
+
+    expect(received).toEqual({
+      minWidth: 50,
+      maxWidth: 50,
+      minHeight: 50,
+      maxHeight: undefined,
+    })
+  })
+
+  it('получение стилей для минимального и максимального размера полного графика с ограничение максимального размера по высоте', () => {
+    const received = getDonutMaxMinSizeRect({
+      height: 100,
+      width: 100,
+      isHalfHorizontal: false,
+      isHalfVertical: false,
+      minSize: 50,
+      limitSizeSide: 'height',
+    })
+
+    expect(received).toEqual({
+      minWidth: 50,
+      maxWidth: undefined,
+      minHeight: 50,
+      maxHeight: 100,
+    })
+  })
+
+  it('получение стилей для минимального и максимального размера полного графика с ограничение максимального размера по ширине', () => {
+    const received = getDonutMaxMinSizeRect({
+      height: 100,
+      width: 100,
+      isHalfHorizontal: false,
+      isHalfVertical: false,
+      minSize: 50,
+      limitSizeSide: 'width',
+    })
+
+    expect(received).toEqual({
+      minWidth: 50,
+      maxWidth: 100,
+      minHeight: 50,
+      maxHeight: undefined,
+    })
   })
 })

--- a/src/__private__/components/CoreDonutChart/helpers.ts
+++ b/src/__private__/components/CoreDonutChart/helpers.ts
@@ -1,3 +1,5 @@
+import { CSSProperties } from 'react'
+
 import { DataItem, HalfDonut } from './CoreDonutChartPie/CoreDonutChartPie'
 
 export const MAX_CIRCLES_TO_RENDER = 3
@@ -20,6 +22,8 @@ export type GetMinChartSize = (
   isExistTextData?: boolean,
   halfDonut?: HalfDonut
 ) => number
+
+export type LimitSizeSide = 'width' | 'height'
 
 export type SortValue = (prev: DataItem, next: DataItem) => number
 
@@ -114,4 +118,34 @@ export const defaultGetMinChartSize: GetMinChartSize = (
 
 export const defaultSortValue: SortValue = (prev, next) => {
   return next.value - prev.value
+}
+
+type GetSizeRectParams = {
+  width: number
+  height: number
+  minSize: number
+  isHalfVertical: boolean
+  isHalfHorizontal: boolean
+  limitSizeSide?: LimitSizeSide
+}
+
+export const getDonutMaxMinSizeRect = ({
+  height,
+  width,
+  minSize,
+  isHalfVertical,
+  isHalfHorizontal,
+  limitSizeSide,
+}: GetSizeRectParams): CSSProperties => {
+  const halfWidth = width / 2
+  const halfHeight = height / 2
+  const maxWidth = limitSizeSide === 'width' ? height : undefined
+  const maxHeight = limitSizeSide === 'height' ? width : undefined
+
+  return {
+    minWidth: isHalfVertical ? halfHeight : minSize,
+    maxWidth: isHalfVertical ? halfHeight : maxWidth,
+    minHeight: isHalfHorizontal ? halfWidth : minSize,
+    maxHeight: isHalfHorizontal ? halfWidth : maxHeight,
+  }
 }


### PR DESCRIPTION
## Описание задачи

Добавить возможность вывода виджета Legend рядом с виджетом DonutChart. Настройки внешнего вида легенды предопределены и не настраиваются, настраивается только положение отображения легенды.

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [x] Тесты: новый функционал и исправленные баги покрыты тестами
- [x] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [x] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются переменные из UI-kit
- [x] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](https://consta-widgets.consta.vercel.app/?path=/docs/common-develop-commits-style--page)
