### PR TITLE
fix(CoreDonutChart): сноски отображаются только на данных для одного кольца

### DIFF
--- a/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
@@ -128,6 +128,7 @@ export const CoreDonutChart: React.FC<Props> = ({
     sortValue,
   ])
   const isTextVisible = values.length === 1 && showText
+  const isArcLabelsVisible = values.length === 1 && showArcLabels
   const piesData = useMemo(() => values.map(item => getPieData(item, halfDonut)), [
     values,
     halfDonut,
@@ -242,7 +243,7 @@ export const CoreDonutChart: React.FC<Props> = ({
             />
           ))}
         </g>
-        {showArcLabels && (
+        {isArcLabelsVisible && (
           <CoreDonutChartLabels
             ref={labelsRef}
             data={labelsPieData}


### PR DESCRIPTION
## Описание задачи

По требованиям сноски должны отображаться только на данных для одного кольца.

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются переменные из UI-kit
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](https://consta-widgets.consta.vercel.app/?path=/docs/common-develop-commits-style--page)
