### PR TITLE
fix(CoreDonutChart): исправлен расчет размера отступа и основного радиуса

### DIFF
--- a/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
+++ b/src/__private__/components/CoreDonutChart/CoreDonutChart.tsx
@@ -137,6 +137,13 @@ export const CoreDonutChart: React.FC<Props> = ({
   const svgSize = getSvgSize({ diameter: mainDiameter, radius: mainRadius, svgOffset, halfDonut })
   const labelsPieData = useMemo(() => (showArcLabels ? piesData[0] : []), [piesData, showArcLabels])
 
+  /**
+   * Необходимо рассчитывать размер отступа каждый раз при изменениях виджета,
+   * в самом перерасчете применяются методы которые не позволят лишний раз
+   * менять состояние компонента, например округление значений расчетов до
+   * целых и проверка того что значения не равны предыдущим.
+   */
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!arcsRef.current || !labelsRef.current) {
       return
@@ -155,11 +162,7 @@ export const CoreDonutChart: React.FC<Props> = ({
     ) {
       setSvgOffset(nextSvgOffset)
     }
-    /**
-     * Перерасчеты нужны только при изменении данных или размерах графика
-     */
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [width, height, data])
+  })
 
   const handleMouseOver = showTooltip
     ? (d: ReadonlyArray<PieArcDatum<ArcDataItem>>) => {

--- a/src/__private__/components/CoreDonutChart/helpers.ts
+++ b/src/__private__/components/CoreDonutChart/helpers.ts
@@ -442,22 +442,16 @@ type GetSvgOffset = {
 }
 
 export const getSvgOffset = ({ arcsRect, labelsRect }: GetSvgOffset) => {
-  const diffX = Math.round(Math.abs(arcsRect.x - labelsRect.x))
-  const diffY = Math.round(Math.abs(labelsRect.y - arcsRect.y))
-  const computedLabelsWidth = Math.round(
-    labelsRect.x > arcsRect.x ? labelsRect.width + diffX : labelsRect.width + labelsRect.x
-  )
-  const computedLabelsHeight = Math.round(
-    labelsRect.y > arcsRect.y ? labelsRect.height + diffY : labelsRect.height + labelsRect.y
-  )
-  const computedArcsWidth = Math.round(arcsRect.width + arcsRect.x)
-  const computedArcsHeight = Math.round(arcsRect.height + arcsRect.y)
-  const offsetTop = labelsRect.y < arcsRect.y ? diffY : 0
-  const offsetLeft = labelsRect.x < arcsRect.x ? diffX : 0
+  const offsetTop = labelsRect.y < arcsRect.y ? Math.round(Math.abs(labelsRect.y - arcsRect.y)) : 0
+  const offsetLeft = labelsRect.x < arcsRect.x ? Math.round(Math.abs(labelsRect.x - arcsRect.x)) : 0
   const offsetRight =
-    computedArcsWidth !== 0 ? Math.max(computedLabelsWidth - computedArcsWidth, 0) : 0
+    arcsRect.width + arcsRect.x < labelsRect.width + labelsRect.x
+      ? Math.round(labelsRect.width + labelsRect.x - (arcsRect.width + arcsRect.x))
+      : 0
   const offsetBottom =
-    computedArcsHeight !== 0 ? Math.max(computedLabelsHeight - computedArcsHeight, 0) : 0
+    arcsRect.height + arcsRect.y < labelsRect.height + labelsRect.y
+      ? Math.round(labelsRect.height + labelsRect.y - (arcsRect.height + arcsRect.y))
+      : 0
   const verticalOffset = Math.max(offsetRight, offsetLeft)
   const horizontalOffset = Math.max(offsetTop, offsetBottom)
 
@@ -501,9 +495,12 @@ export const getMainRadius = ({ width, height, svgOffset, halfDonut }: GetMainRa
   const widthDivider = isHalfDonutVertical(halfDonut) ? 1 : 2
   const heightDivider = isHalfDonutHorizontal(halfDonut) ? 1 : 2
 
-  return Math.min(
-    Math.floor((width - svgOffset.right - svgOffset.left) / widthDivider),
-    Math.floor((height - svgOffset.top - svgOffset.bottom) / heightDivider)
+  return Math.max(
+    Math.min(
+      Math.floor((width - svgOffset.right - svgOffset.left) / widthDivider),
+      Math.floor((height - svgOffset.top - svgOffset.bottom) / heightDivider)
+    ),
+    MIN_RADIUS
   )
 }
 


### PR DESCRIPTION
## Описание задачи

Нашли проблему с отображением подписей вокруг графика, в PR исправления для решения проблемы неправильных расчетов отступов и радиуса графика.

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются переменные из UI-kit
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [x] Коммиты: проименованы в соответствии с [правилами](https://consta-widgets.consta.vercel.app/?path=/docs/common-develop-commits-style--page)
